### PR TITLE
Migrate to 2021 edition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,17 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.54
+          - 1.56.1
     steps:
-    - uses: actions/checkout@v2.3.5
-    - uses: actions-rs/toolchain@v1.0.7
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
-        override: true
-    - uses: actions-rs/cargo@v1.0.3
-      with:
-        command: check
+      - uses: actions/checkout@v2.3.5
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
 
   test:
     name: Test
@@ -29,33 +29,33 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.54
+          - 1.56.1
     steps:
-    - uses: actions/checkout@v2.3.5
-    - uses: actions-rs/toolchain@v1.0.7
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
-        override: true
-    - uses: actions-rs/cargo@v1.0.3
-      with:
-        command: test
+      - uses: actions/checkout@v2.3.5
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.5
-    - uses: actions-rs/toolchain@v1.0.7
-      with:
-        profile: minimal
-        toolchain: stable
-        components: rustfmt
-        override: true
-    - uses: actions-rs/cargo@v1.0.3
-      with:
-        command: fmt
-        args: --all -- --check
+      - uses: actions/checkout@v2.3.5
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fmt
+          args: --all -- --check
 
   clippy:
     name: Clippy
@@ -64,65 +64,65 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.54
+          - 1.56.1
     steps:
-    - uses: actions/checkout@v2.3.5
-    - uses: actions-rs/toolchain@v1.0.7
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
-        components: clippy
-        override: true
-    - uses: actions-rs/cargo@v1.0.3
-      with:
-        command: clippy
-        args: -- -Dwarnings
+      - uses: actions/checkout@v2.3.5
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          components: clippy
+          override: true
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: clippy
+          args: -- -Dwarnings
 
   miri:
     name: Miri
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.5
-    - name: Miri nightly
-      id: miri_nightly
-      run: |
-        MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
-        echo "::set-output name=rust::${MIRI_NIGHTLY}"
-    - uses: actions-rs/toolchain@v1.0.7
-      with:
-        profile: minimal
-        toolchain: ${{ steps.miri_nightly.outputs.rust }}
-        components: miri
-        default: true
-    - uses: actions-rs/cargo@v1.0.3
-      with:
-        command: miri
-        args: test
+      - uses: actions/checkout@v2.3.5
+      - name: Miri nightly
+        id: miri_nightly
+        run: |
+          MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+          echo "::set-output name=rust::${MIRI_NIGHTLY}"
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: ${{ steps.miri_nightly.outputs.rust }}
+          components: miri
+          default: true
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: miri
+          args: test
 
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '-Zinstrument-coverage'
-      RUSTDOCFLAGS: '-Zinstrument-coverage'
+      RUSTFLAGS: "-Zinstrument-coverage"
+      RUSTDOCFLAGS: "-Zinstrument-coverage"
     steps:
-    - uses: actions/checkout@v2.3.5
-    - uses: actions-rs/toolchain@v1.0.7
-      with:
-        profile: minimal
-        toolchain: nightly
-        components: llvm-tools-preview
-        override: true
-    - uses: actions-rs/cargo@v1.0.3
-      with:
-        command: build
-    - uses: actions-rs/cargo@v1.0.3
-      env:
-        LLVM_PROFILE_FILE: 'narrow-%p-%m.profraw'
-      with:
-        command: test
-    - name: Install grcov
-      run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
-    - name: grcov
-      run: ./grcov --branch --binary-path ./target/debug/ --source-dir . --output-type lcov --output-path lcov.info .
-    - uses: codecov/codecov-action@v2.1.0
+      - uses: actions/checkout@v2.3.5
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: llvm-tools-preview
+          override: true
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+      - uses: actions-rs/cargo@v1.0.3
+        env:
+          LLVM_PROFILE_FILE: "narrow-%p-%m.profraw"
+        with:
+          command: test
+      - name: Install grcov
+        run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+      - name: grcov
+        run: ./grcov --branch --binary-path ./target/debug/ --source-dir . --output-type lcov --output-path lcov.info .
+      - uses: codecov/codecov-action@v2.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "narrow"
 version = "0.1.0"
 authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 description = "A Rust implementation of Apache Arrow"
 readme = "README.md"
 repository = "https://github.com/mbrobbel/narrow"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A Rust implementation of [Apache Arrow](https://arrow.apache.org).
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version is 1.54.
+The minimum supported Rust version is 1.56.1.
 
 ## Example
 

--- a/narrow-derive/Cargo.toml
+++ b/narrow-derive/Cargo.toml
@@ -2,7 +2,8 @@
 name = "narrow-derive"
 version = "0.1.0"
 authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 description = "Derive macros for Narrow: A Rust implementation of Apache Arrow"
 readme = "../README.md"
 repository = "https://github.com/mbrobbel/narrow"

--- a/narrow-derive/src/lib.rs
+++ b/narrow-derive/src/lib.rs
@@ -116,7 +116,7 @@ pub fn derive_array(input: TokenStream) -> TokenStream {
                         }
 
                         #[automatically_derived]
-                        impl ::std::iter::FromIterator<#ident> for #wrapper_ident
+                        impl FromIterator<#ident> for #wrapper_ident
                         {
                             fn from_iter<I>(iter: I) -> Self
                             where
@@ -288,7 +288,7 @@ pub fn derive_array(input: TokenStream) -> TokenStream {
                 }
 
                 #[automatically_derived]
-                impl ::std::iter::FromIterator<#ident> for #wrapper_ident<false> {
+                impl FromIterator<#ident> for #wrapper_ident<false> {
                     fn from_iter<I>(iter: I) -> Self
                     where
                         I: ::std::iter::IntoIterator<Item = #ident>,
@@ -321,7 +321,7 @@ pub fn derive_array(input: TokenStream) -> TokenStream {
                 }
 
                 #[automatically_derived]
-                impl ::std::iter::FromIterator<#ident> for #wrapper_ident<true> {
+                impl FromIterator<#ident> for #wrapper_ident<true> {
                     fn from_iter<I>(iter: I) -> Self
                     where
                         I: ::std::iter::IntoIterator<Item = #ident>,

--- a/src/array/boolean.rs
+++ b/src/array/boolean.rs
@@ -1,5 +1,5 @@
 use crate::{Array, ArrayIndex, ArrayType, Bitmap, Nullable, Validity};
-use std::{iter::FromIterator, ops::Deref};
+use std::ops::Deref;
 
 /// Array with boolean values.
 ///

--- a/src/array/dictionary.rs
+++ b/src/array/dictionary.rs
@@ -1,10 +1,8 @@
 use crate::{Array, ArrayIndex, FixedSizePrimitiveArray, NestedArray, Primitive};
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     hash::{Hash, Hasher},
-    iter::FromIterator,
 };
 
 /// Types representing dictionary index values.

--- a/src/array/fixed_size_list.rs
+++ b/src/array/fixed_size_list.rs
@@ -1,7 +1,7 @@
 use crate::{Array, ArrayType, Bitmap, NestedArray, Validity};
 use std::{
     array::{self, IntoIter},
-    iter::{FromIterator, Skip, Take},
+    iter::{Skip, Take},
 };
 
 /// Array with fixed-size lists of other array types.

--- a/src/array/fixed_size_primitive.rs
+++ b/src/array/fixed_size_primitive.rs
@@ -1,6 +1,6 @@
 use crate::{Array, ArrayData, ArrayIndex, Buffer, Nullable, Primitive, Validity, ALIGNMENT};
 use paste::paste;
-use std::{iter::FromIterator, ops::Deref};
+use std::ops::Deref;
 
 /// Array with primitive values.
 #[derive(Debug)]

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -64,7 +64,7 @@ pub trait Array {
     ///
     /// ```
     /// use narrow::{Array, Uint32Array};
-    /// let empty: Uint32Array<false> = [].into_iter().collect();
+    /// let empty: Uint32Array<false> = [].iter().collect();
     /// assert!(empty.is_empty());
     /// ```
     fn is_empty(&self) -> bool {
@@ -103,7 +103,7 @@ pub trait Array {
     ///
     /// ```
     /// use narrow::{Array, Uint32Array};
-    /// let array: Uint32Array<true> = [None, None, None, None].into_iter().collect();
+    /// let array: Uint32Array<true> = [None, None, None, None].iter().collect();
     /// assert!(array.all_null());
     /// ```
     fn all_null(&self) -> bool {

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -1,5 +1,5 @@
 use crate::{Array, ArrayIndex, ArrayType};
-use std::iter::{self, FromIterator, Repeat, Take};
+use std::iter::{self, Repeat, Take};
 
 /// A sequence of nulls.
 #[derive(Debug)]

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -3,7 +3,7 @@ use crate::{
     VariableSizeBinaryArrayIter,
 };
 use std::{
-    iter::{FromIterator, Map},
+    iter::Map,
     ops::{Deref, Index},
 };
 

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -1,5 +1,5 @@
 use crate::{Array, ArrayData, ArrayType, Nullable, Validity};
-use std::{fmt::Debug, iter::FromIterator, ops::Deref};
+use std::{fmt::Debug, ops::Deref};
 
 // todo(mb): add partial eq with array of struct
 

--- a/src/array/union.rs
+++ b/src/array/union.rs
@@ -1,7 +1,7 @@
 use crate::{Array, ArrayData, Int32Array, Int8Array, NestedArray};
 use std::{
     fmt::Debug,
-    iter::{Copied, Enumerate, FromIterator, Zip},
+    iter::{Copied, Enumerate, Zip},
     ops::Deref,
     slice,
 };

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -1,5 +1,5 @@
 use crate::{Array, ArrayIndex, ArrayType, Buffer, Offset, OffsetValue, ALIGNMENT};
-use std::{iter::FromIterator, ops::Index};
+use std::ops::Index;
 
 /// Array with variable-sized binary data.
 #[derive(Debug)]
@@ -38,8 +38,8 @@ where
     type Output = Vec<u8>;
 
     fn index(&self, index: usize) -> Self::Output {
-        let start = self.offset.index(index).try_into().unwrap();
-        let end = self.offset.index(index + 1).try_into().unwrap();
+        let start = (*self.offset.index(index)).try_into().unwrap();
+        let end = (*self.offset.index(index + 1)).try_into().unwrap();
         self.data[start..end].to_vec()
     }
 }

--- a/src/array/variable_size_list.rs
+++ b/src/array/variable_size_list.rs
@@ -1,6 +1,6 @@
 use crate::{Array, ArrayIndex, ArrayType, NestedArray, Offset, OffsetValue};
 use std::{
-    iter::{FromIterator, Skip, Take},
+    iter::{Skip, Take},
     ops::{Index, Range},
 };
 

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -4,7 +4,7 @@ use bitvec::{
     slice::{BitSlice, BitValIter},
     view::BitView,
 };
-use std::{iter::FromIterator, ops::Deref};
+use std::ops::Deref;
 
 /// An immutable collection of bits.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,7 +4,7 @@ use std::{
     any,
     borrow::Borrow,
     fmt::{Debug, Formatter, Result},
-    iter::{Copied, FromIterator},
+    iter::Copied,
     mem,
     ops::Deref,
     ptr::{self, NonNull},
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn as_ref() {
-        let buffer: Buffer<_, 7> = [1u32, 2, 3, 4].iter().copied().collect();
+        let buffer: Buffer<_, 7> = [1u32, 2, 3, 4].into_iter().collect();
         let x: &Buffer<_, 7> = buffer.as_ref();
         assert_eq!(x.len(), 4);
         let x: &[u8] = buffer.as_ref();
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn borrow() {
-        let buffer: Buffer<_, 7> = [1u32, 2, 3, 4].iter().copied().collect();
+        let buffer: Buffer<_, 7> = [1u32, 2, 3, 4].into_iter().collect();
 
         fn borrow_u32<T: Borrow<[u32]>>(input: T) {
             assert_eq!(input.borrow(), &[1, 2, 3, 4]);
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn deref() {
-        let buffer: Buffer<_, 3> = [1u32, 2, 3, 4].iter().copied().collect();
+        let buffer: Buffer<_, 3> = [1u32, 2, 3, 4].into_iter().collect();
         assert_eq!(buffer.len(), 4);
         assert_eq!(&buffer[2..], &[3, 4]);
     }

--- a/src/nullable.rs
+++ b/src/nullable.rs
@@ -1,6 +1,6 @@
 use crate::{ArrayData, ArrayIndex, Bitmap};
 use bitvec::{order::Lsb0, slice::BitValIter};
-use std::iter::{FromIterator, Map, Zip};
+use std::iter::{Map, Zip};
 
 /// Wrapper for nullables data.
 ///
@@ -26,11 +26,11 @@ impl<T> Nullable<T> {
     /// use narrow::{Bitmap, Buffer, Nullable};
     ///
     /// let nullable: Nullable<Buffer<u32, 6>> =
-    ///     [Some(1u32), None, Some(3), Some(4)].iter().copied().collect();
+    ///     [Some(1u32), None, Some(3), Some(4)].into_iter().collect();
     ///
     /// assert_eq!(
     ///     nullable.validity(),
-    ///     &[true, false, true, true].iter().copied().collect::<Bitmap>()
+    ///     &[true, false, true, true].into_iter().collect::<Bitmap>()
     /// );
     /// ```
     pub fn validity(&self) -> &Bitmap {
@@ -45,9 +45,9 @@ impl<T> Nullable<T> {
     /// use narrow::{Bitmap, Buffer, Nullable};
     ///
     /// let nullable: Nullable<Buffer<u32, 6>> =
-    ///     [Some(1u32), None, Some(3), Some(4)].iter().copied().collect();
+    ///     [Some(1u32), None, Some(3), Some(4)].into_iter().collect();
     ///
-    /// assert_eq!(nullable.data(), &[1u32, u32::default(), 3, 4].iter().copied().collect());
+    /// assert_eq!(nullable.data(), &[1u32, u32::default(), 3, 4].into_iter().collect());
     /// ```
     pub fn data(&self) -> &T {
         &self.data
@@ -148,14 +148,11 @@ mod tests {
             .collect::<Nullable<Buffer<_, 3>>>();
         assert_eq!(
             nullable.validity(),
-            &[true, false, true, true]
-                .iter()
-                .copied()
-                .collect::<Bitmap>()
+            &[true, false, true, true].into_iter().collect::<Bitmap>()
         );
         assert_eq!(
             nullable.data(),
-            &[1, u32::default(), 3, 4].iter().copied().collect()
+            &[1, u32::default(), 3, 4].into_iter().collect()
         );
         assert_eq!(nullable.len(), 4);
         assert_eq!(nullable.null_count(), 1);
@@ -196,10 +193,8 @@ mod tests {
 
     #[test]
     fn into_iter() {
-        let nullable: Nullable<Buffer<u8, 1>> = [Some(1u8), None, Some(3), Some(4)]
-            .iter()
-            .copied()
-            .collect();
+        let nullable: Nullable<Buffer<u8, 1>> =
+            [Some(1u8), None, Some(3), Some(4)].into_iter().collect();
         let vec = nullable.into_iter().collect::<Vec<_>>();
         assert_eq!(vec, vec![Some(1u8), None, Some(3), Some(4)]);
     }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -1,8 +1,7 @@
 use crate::{ArrayData, Bitmap, BitmapIter, Buffer, Primitive, Validity, ALIGNMENT};
 use bitvec::{order::Lsb0, slice::BitValIter};
 use std::{
-    convert::{TryFrom, TryInto},
-    iter::{self, Copied, FromIterator, Zip},
+    iter::{self, Copied, Zip},
     num::TryFromIntError,
     ops::Deref,
     slice::Iter,
@@ -247,14 +246,14 @@ mod tests {
 
     #[test]
     fn array_data() {
-        let offset: Offset<i64, false> = [1, 2, 3, 4].iter().copied().collect();
+        let offset: Offset<i64, false> = [1, 2, 3, 4].into_iter().collect();
         assert_eq!(offset.len(), 4);
         assert!(!offset.is_null(0));
         assert_eq!(offset.null_count(), 0);
         assert!(offset.is_valid(0));
         assert_eq!(offset.valid_count(), 4);
 
-        let offset: Offset<i32, true> = [Some(3), None, Some(4), Some(0)].iter().copied().collect();
+        let offset: Offset<i32, true> = [Some(3), None, Some(4), Some(0)].into_iter().collect();
         assert_eq!(offset.len(), 4);
         assert!(!offset.is_null(0));
         assert!(offset.is_null(1));
@@ -266,22 +265,21 @@ mod tests {
 
     #[test]
     fn from_iter() {
-        let offset: Offset<i64, false> = [1, 2, 3, 4].iter().copied().collect();
+        let offset: Offset<i64, false> = [1, 2, 3, 4].into_iter().collect();
         assert_eq!(&offset[..], &[0, 1, 3, 6, 10]);
 
-        let offset: Offset<i32, true> = [Some(3), None, Some(4), Some(0)].iter().copied().collect();
+        let offset: Offset<i32, true> = [Some(3), None, Some(4), Some(0)].into_iter().collect();
         assert_eq!(&offset.data()[..], &[0, 3, 3, 7, 7]);
     }
 
     #[test]
     fn into_iter() {
-        let offset: Offset<i64, false> = [1, 2, 3, 4].iter().copied().collect();
+        let offset: Offset<i64, false> = [1, 2, 3, 4].into_iter().collect();
         let offsets = offset.into_iter().collect::<Vec<_>>();
         assert_eq!(offsets, vec![(0, 1), (1, 3), (3, 6), (6, 10)]);
 
         let offset: Offset<i32, true> = [Some(3), None, Some(4), None, Some(0)]
-            .iter()
-            .copied()
+            .into_iter()
             .collect();
         let offsets = offset.into_iter().collect::<Vec<_>>();
         assert_eq!(

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -1,5 +1,5 @@
 use crate::{ArrayData, ArrayIndex, Bitmap, Nullable};
-use std::{hint::unreachable_unchecked, iter::FromIterator, ops::Deref};
+use std::{hint::unreachable_unchecked, ops::Deref};
 
 /// Variants for nullable and non-nullable data.
 ///


### PR DESCRIPTION
- Removed `TryInto`/`TryFrom`/`FromIterator` use statements
- Use `array.into_iter()` instead of `iter().copied()`