### PR TITLE
Modify NullArray to support Array derive for unit structs

### DIFF
--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -1,10 +1,36 @@
 use crate::{Array, ArrayIndex, ArrayType};
-use std::iter::{self, Repeat, Take};
+use std::{
+    iter::{self, Repeat, Take},
+    marker::PhantomData,
+};
 
 /// A sequence of nulls.
-#[derive(Debug)]
-pub struct NullArray {
+///
+/// This array type is also used as [ArrayType] when deriving [Array] for types
+/// without fields (unit types). The generic `T` is used to provide iterator
+/// implementations for array of these unit types.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct NullArray<T = ()> {
     len: usize,
+    _ty: PhantomData<fn() -> T>,
+}
+
+impl<T> NullArray<T> {
+    /// Returns a new NullArray with the given length.
+    ///
+    /// This never allocates.
+    pub fn with_len(len: usize) -> Self {
+        Self {
+            len,
+            _ty: PhantomData,
+        }
+    }
+
+    /// Returns the number of elements in the array, also referred to as its
+    /// length.
+    pub fn len(&self) -> usize {
+        self.len
+    }
 }
 
 impl Array for NullArray {
@@ -73,8 +99,11 @@ impl Array for NullArray {
     }
 }
 
-impl ArrayIndex<usize> for NullArray {
-    type Output = ();
+impl<T> ArrayIndex<usize> for NullArray<T>
+where
+    T: Default,
+{
+    type Output = T;
 
     fn index(&self, index: usize) -> Self::Output {
         #[cold]
@@ -87,6 +116,8 @@ impl ArrayIndex<usize> for NullArray {
         if index >= len {
             assert_failed(index, len);
         }
+
+        T::default()
     }
 }
 
@@ -94,22 +125,73 @@ impl ArrayType for () {
     type Array = NullArray;
 }
 
-impl FromIterator<()> for NullArray {
+impl<T> FromIterator<T> for NullArray<T> {
     fn from_iter<I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = ()>,
+        I: IntoIterator<Item = T>,
     {
         Self {
             len: iter.into_iter().count(),
+            _ty: PhantomData,
         }
     }
 }
 
-impl<'a> IntoIterator for &'a NullArray {
-    type Item = ();
-    type IntoIter = Take<Repeat<()>>;
+impl<'a, T> IntoIterator for &'a NullArray<T>
+where
+    T: Clone + Default,
+{
+    type Item = T;
+    type IntoIter = Take<Repeat<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        iter::repeat(()).take(self.len)
+        iter::repeat(T::default()).take(self.len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_iter() {
+        let vec = vec![(); 100];
+        let array = vec.into_iter().collect::<NullArray>();
+        assert_eq!(array.len(), 100);
+        assert!(array.is_null(0));
+    }
+
+    #[test]
+    fn into_iter() {
+        let vec = vec![(); 100];
+        let array = vec.iter().copied().collect::<NullArray>();
+        assert_eq!(vec, array.into_iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn unit_type() {
+        #[derive(Clone, Default, Debug, PartialEq)]
+        struct UnitStruct;
+
+        let vec = vec![UnitStruct; 100];
+        let array = vec.iter().cloned().collect::<NullArray<_>>();
+        assert_eq!(array.len(), 100);
+        assert_eq!(vec, array.into_iter().collect::<Vec<_>>());
+
+        #[derive(Clone, Debug, PartialEq)]
+        enum UnitEnum {
+            Unit,
+        }
+
+        impl Default for UnitEnum {
+            fn default() -> Self {
+                UnitEnum::Unit
+            }
+        }
+
+        let vec = vec![UnitEnum::default(); 100];
+        let array = vec.iter().cloned().collect::<NullArray<_>>();
+        assert_eq!(array.len(), 100);
+        assert_eq!(vec, array.into_iter().collect::<Vec<_>>());
     }
 }

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -31,6 +31,11 @@ impl<T> NullArray<T> {
     pub fn len(&self) -> usize {
         self.len
     }
+
+    /// Returns `true` if the array contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 impl Array for NullArray {

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -1,8 +1,5 @@
 use crate::{Array, ArrayIndex, ArrayType};
-use std::{
-    iter::{self, Repeat, Take},
-    marker::PhantomData,
-};
+use std::{iter::Map, marker::PhantomData, ops::Range};
 
 /// A sequence of nulls.
 ///
@@ -144,13 +141,13 @@ impl<T> FromIterator<T> for NullArray<T> {
 
 impl<'a, T> IntoIterator for &'a NullArray<T>
 where
-    T: Clone + Default,
+    T: Default,
 {
     type Item = T;
-    type IntoIter = Take<Repeat<T>>;
+    type IntoIter = Map<Range<usize>, fn(usize) -> T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        iter::repeat(T::default()).take(self.len)
+        (0..self.len).into_iter().map(|_| T::default())
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Zero-sized layouts are not supported")]
     fn layout_zero_sized() {
-        layout::<u8, 0>(0).size();
+        layout::<u8, 0>(0);
     }
 
     #[test]


### PR DESCRIPTION
The goal is to enable `Array` derive support for zero-sized types like unit structs or enums with one variant.